### PR TITLE
Optimize ladder data structure for prediction

### DIFF
--- a/scripts/mushroom.sh
+++ b/scripts/mushroom.sh
@@ -15,7 +15,7 @@ java -jar $JAR split 8:2 mushroom.dat training.dat verify.dat
 echo "---"
 java -jar $JAR tau verify.dat tau.dat
 echo "---"
-java -jar $JAR generate -apcbo -m model.dat training.dat
+java -jar $JAR generate -m model.dat training.dat
 echo "---"
 java -jar $JAR predict -m model.dat -o predictions.dat tau.dat
 echo "---"

--- a/src/main/scala/jsm4s/algorithm/Predictor.scala
+++ b/src/main/scala/jsm4s/algorithm/Predictor.scala
@@ -7,6 +7,7 @@ import jsm4s.Utils._
 import jsm4s.algorithm.Strategies.MergeStrategy
 
 import scala.collection.mutable
+import scala.util.Random
 
 // Ladder overview:
 // first element - hypotheses that contain given attribute
@@ -35,7 +36,7 @@ class Predictor(val hypotheses: Seq[Hypothesis], val attrs: Int, val mergeStrate
           weight(i) += 1
           total += 1
         }
-        i += 3
+        i += 7
       }
     }
     val sorted = timeIt("Weights sorting")(weight.zipWithIndex.filter(_._1 > threshold).sortWith((a, b) => a._1 < b._1))
@@ -58,7 +59,11 @@ class Predictor(val hypotheses: Seq[Hypothesis], val attrs: Int, val mergeStrate
 
   private val tree = buildLadder
 
-  def search(example: FcaSet): Seq[Hypothesis] = tree.ladder.flatMap(p => if (example.contains(p._1)) p._2 else Seq.empty) ++ tree.rem
+  def search(example: FcaSet): Seq[Hypothesis] = {
+    val collected = tree.ladder.flatMap(p => if (example.contains(p._1)) p._2 else Seq.empty)
+    if (tree.rem.nonEmpty) collected ++ tree.rem
+    else collected
+  }
 
   def apply(example: FcaSet):Properties = {
     val hyps = search(example)

--- a/src/main/scala/jsm4s/algorithm/Predictor.scala
+++ b/src/main/scala/jsm4s/algorithm/Predictor.scala
@@ -8,41 +8,57 @@ import jsm4s.algorithm.Strategies.MergeStrategy
 
 import scala.collection.mutable
 
-case class Tree(splits: Seq[(Int, Seq[Hypothesis])], rem: Seq[Hypothesis])
+// Ladder overview:
+// first element - hypotheses that contain given attribute
+// second - that contain given attribute but not the one from first split
+// third - doesn't contain 1 & 2 but contains yet another attribute
+// ...
+// ladder are constructed by going this way from less popular to more popular attributes
+//
+case class Ladder(ladder: Seq[(Int, Seq[Hypothesis])], rem: Seq[Hypothesis])
 
 class Predictor(val hypotheses: Seq[Hypothesis], val attrs: Int, val mergeStrategy: MergeStrategy)
-extends LazyLogging {
+  extends LazyLogging {
 
-  private def buildTree: Tree = {
+
+  private def buildLadder: Ladder = {
+    val portion = 0.05 // exclude all attributes that sum up to less then `portion` of total
+    val threshold = 20 // minimum weight to consider, trims down on fruitless computation
     var remaining = hypotheses
     val weight = Array.ofDim[Int](attrs)
-    timeIt("Weight calculation") {
+    var total = 0.0
+    timeIt("Weights calculation") {
       var i = 0
       while(i < hypotheses.size) {
         val h = hypotheses(i)
         for (i <- h.intent) {
           weight(i) += 1
+          total += 1
         }
-        i += 7
+        i += 3
       }
     }
-    val sorted = timeIt("Hypotheses sorting")(weight.zipWithIndex.filter(_._1 > 20).sortWith((a, b) => a._1 < b._1))
-    val topAttrs = sorted.map(_._2)
-    timeIt("Tree building") {
+    val sorted = timeIt("Weights sorting")(weight.zipWithIndex.filter(_._1 > threshold).sortWith((a, b) => a._1 < b._1))
+    val cumulative = sorted.map(_._1 / total).scanLeft(0.0)((acc, x) => acc + x)
+    val significant = cumulative.indexWhere(_ > portion)
+    val topAttrs = sorted.slice(significant, sorted.length).map(_._2)
+    timeIt("Ladder building") {
       val buf = mutable.Buffer[(Int, Seq[Hypothesis])]()
       for (j <- topAttrs) {
-        val parts = remaining.partition { x => x.intent.contains(j) }
-        buf += j -> parts._1
-        remaining = parts._2
+        if (remaining.nonEmpty) {
+          val parts = remaining.partition { x => x.intent.contains(j) }
+          buf += j -> parts._1
+          remaining = parts._2
+        }
       }
       logger.info("Reminder size is {}", remaining.size)
-      Tree(buf, remaining)
+      Ladder(buf, remaining)
     }
   }
 
-  private val tree = buildTree
+  private val tree = buildLadder
 
-  def search(example: FcaSet): Seq[Hypothesis] = tree.splits.flatMap(p => if (example.contains(p._1)) p._2 else Seq()) ++ tree.rem
+  def search(example: FcaSet): Seq[Hypothesis] = tree.ladder.flatMap(p => if (example.contains(p._1)) p._2 else Seq.empty) ++ tree.rem
 
   def apply(example: FcaSet):Properties = {
     val hyps = search(example)

--- a/src/main/scala/jsm4s/algorithm/Strategies.scala
+++ b/src/main/scala/jsm4s/algorithm/Strategies.scala
@@ -1,6 +1,6 @@
 package jsm4s.algorithm
 
-import jsm4s.property.{Properties, Property}
+import jsm4s.property.{BinaryProperty, Properties, Property}
 
 import scala.collection.mutable
 
@@ -9,8 +9,24 @@ object Strategies {
   type MergeStrategy = Seq[Properties] => Properties
 
   def votingMajority(seq: Seq[Properties]): Properties = {
-    if (seq.isEmpty) Properties(Seq())
-    else {
+    if (seq.isEmpty) Properties(Seq.empty)
+    /*else if (seq.head.value.head.isInstanceOf[BinaryProperty] && seq.head.value.length < 32) {
+      val len = seq.head.size
+      val votes = Array.fill(len)(0)
+      seq.foreach {
+        case Properties(props) =>
+          for (i <- 0 until len) {
+            if (props(i).asInstanceOf[BinaryProperty].positive) votes(i) += 1
+            else votes(i) -= 1
+          }
+      }
+      new Properties(votes.map { x =>
+        if(x > 0) new BinaryProperty(1)
+        else if (x < 0) new BinaryProperty(2)
+        else new BinaryProperty(3)
+      })
+    }*/
+    else { // generic property code
       val len = seq.head.size
       val votes = Array.fill(len)(mutable.Map[Property, Int]())
       seq.foreach {

--- a/src/main/scala/jsm4s/ds/SortedArray.scala
+++ b/src/main/scala/jsm4s/ds/SortedArray.scala
@@ -20,7 +20,7 @@ class SortedArray(var table: Array[Int], var tsize: Int) extends FcaSet with Ite
     }
   }
 
-  override def foreach[U](f: (Int) => U): Unit = {
+  override def foreach[U](f: Int => U): Unit = {
     var i = 0
     while (i < tsize) {
       f(table(i))

--- a/src/main/scala/jsm4s/property/BinaryProperty.scala
+++ b/src/main/scala/jsm4s/property/BinaryProperty.scala
@@ -26,7 +26,7 @@ object BinaryProperty{
     new BinaryProperty(props.foldLeft(3)((a, x) => a & x.value))
 
   def factory(values: SortedSet[String]):Property.Factory = {
-    if (values.size != 2) throw  new PropertyException(s"Illegal number of values for bianry property `${values.size}")
+    if (values.size != 2) throw  new PropertyException(s"Illegal number of values for binary property `${values.size}")
     val first = values.head
     (x) => {
       if (x == first) new BinaryProperty(1)

--- a/src/main/scala/jsm4s/property/Properties.scala
+++ b/src/main/scala/jsm4s/property/Properties.scala
@@ -2,7 +2,7 @@ package jsm4s.property
 
 import scala.collection.mutable
 
-case class Properties(val value: Seq[Property]){
+case class Properties(value: Seq[Property]){
 
   def &(props: Properties): Properties = Properties(value.zip(props.value).map(p => p._1 & p._2))
 


### PR DESCRIPTION
By droping the first steps of ladder that amout to (for now) to 5% we get to significantly speed up this _serial_ step.

The tradeoff is that the actual prediction is now taking longer as we try to fit more of irrelevant hypothesis.